### PR TITLE
14 missing links

### DIFF
--- a/docs/Advanced/part4.md
+++ b/docs/Advanced/part4.md
@@ -27,10 +27,10 @@ This part contains the basic knowledge on understanding and learning to use NOMA
 
 which can be downloaded here:
 <center>
-[Download example_files.zip](../../assets/part4_workflows/example_files.zip){ .md-button }
+[Download example_files.zip](../assets/part4_workflows/example_files.zip){ .md-button }
 </center>
 
-Each of the _mainfiles_ represent an electronic-structure calculation (either [DFT](https://en.wikipedia.org/wiki/Density_functional_theory), [TB](https://en.wikipedia.org/wiki/Tight_binding), or [DMFT](https://en.wikipedia.org/wiki/Dynamical_mean-field_theory)) which in turn is then parsed into a singular _entry_ in NOMAD. When dragged into the [NOMAD Upload page](https://nomad-lab.eu/prod/v1/staging/gui/user/uploads), these files should generate 8 entries in total. This folder structure presents a typical workflow calculation which can be represented as a provenance graph:
+Each of the _mainfiles_ represent an electronic-structure calculation (either [DFT](https://en.wikipedia.org/wiki/Density_functional_theory){:target="_blank"}, [TB](https://en.wikipedia.org/wiki/Tight_binding){:target="_blank"}, or [DMFT](https://en.wikipedia.org/wiki/Dynamical_mean-field_theory){:target="_blank"}) which in turn is then parsed into a singular _entry_ in NOMAD. When dragged into the [NOMAD Upload page](https://nomad-lab.eu/prod/v1/staging/gui/user/uploads){:target="_blank"}, these files should generate 8 entries in total. This folder structure presents a typical workflow calculation which can be represented as a provenance graph:
 ```mermaid
 graph LR;
     A2((Inputs)) --> B2[DFT];
@@ -60,7 +60,7 @@ The goal of this part is to set up the following workflows:
 
 The files for all these cases can be downloaded here:
 <center>
-[Download worfklowyaml_files.zip](../../assets/part4_workflows/workflowyaml_files.zip){ .md-button }
+[Download worfklowyaml_files.zip](../assets/part4_workflows/workflowyaml_files.zip){ .md-button }
 </center>
 
  You can try writing these files yourself first, and then compare them with the tested files.

--- a/docs/Tutorial-1_Uploading_MD_Data.md
+++ b/docs/Tutorial-1_Uploading_MD_Data.md
@@ -4,14 +4,14 @@ There are several ways to upload your data to NOMAD:
 
 - By dragging-and-dropping your files into the `PUBLISH > Uploads` page.
 - By using the shell command `curl` for sending files for upload.
-- By using the python `response` library to execute python-based [NOMAD API](../glossary/glossary.md/#api).
+- By using the python `response` library to submit a query to the NOMAD API.
 
 For this tutorial, we will stick to the simple drag-and-drop method. However, some information about the python API for uploading is provided under the [`Advanced > Using python API for uploading`](Advanced/Upload_API.md).
 
 In general, you can upload files one by one or upload entire file structures in `.zip` or `.tar.gz` formats. First, download the zip file with the example simulation data for this part of the tutorial:
 
 <center>
-[Download Test Data](../assets/md_tutorial_1/water_workflow.zip){ .md-button }
+[Download Test Data](assets/md_tutorial_1/water_workflow.zip){:target="_blank" .md-button }
 </center>
 
 Take a minute to examine the directory structure. If you are familiar with Gromacs you will immediately see the input/output from 3 simulations: an energy minimization (`Emin/`), an NPT equilibration (`Equil-NPT/`), and an NVT production run (`Prod-NVT/`). In the main directory, you will also see a .yaml file, which contains the NOMAD schema for connecting these 3 simulations into a workflow. More information about these custom workflow schemas can be found under [`Advanced > Creating custom workflows`](Advanced/part4.md).
@@ -42,13 +42,13 @@ After the files are uploaded, a **processing** is triggered. In brief, NOMAD int
 
     The **mainfiles** are those files which are representative of a given computational calculation. The presence of a mainfile in the upload is required for NOMAD to recognize a calculation. NOMAD supports several computational codes for first principles calculations, molecular dynamics simulations, and lattice modeling, as well as workflow and database managers. Currently, both the Gromacs and Lammps packages are supported. We are also developing a *custom schema based on the H5MD format*, to allow users to upload simulation data run with any MD engine.
 
-    For each supported code, NOMAD recognizes a single file as the mainfile. For example, the Gromacs mainfile is the native `.log` file created during the simulation. The remaining files that have not been identified as mainfiles are designated as **auxiliary files**. You can find further information about the various supported codes, mainfiles, and auxiliary files in the general NOMAD documentation under [Supported parsers](https://nomad-lab.eu/prod/v1/staging/docs/reference/parsers.html).
+    For each supported code, NOMAD recognizes a single file as the mainfile. For example, the Gromacs mainfile is the native `.log` file created during the simulation. The remaining files that have not been identified as mainfiles are designated as **auxiliary files**. You can find further information about the various supported codes, mainfiles, and auxiliary files in the general NOMAD documentation under [Supported parsers](https://nomad-lab.eu/prod/v1/staging/docs/reference/parsers.html){:target="_blank"}.
 
 
 ??? tip
     We recommend to keep as many auxiliary files as possible together with the mainfile, but without exceeding the uploads limit&mdash;32GB file size limit per upload. For the routine upload of simulations that exceed this limit, we suggest that you prune the trajectory file in advance, to store only a subset of the data on the NOMAD repository. In this case, the parsers should still correctly store the configurations as well as additional metadata dealing with the input parameters to the simulation.
 
-    For special cases of larger simulations or datasets that must be stored in full, special processing procedures are required. In this case, you should contact the [NOMAD/FAIRmat team]() for assistance. Alternatively, you can post questions or requests on the [NOMAD MATSCI Community Discourse Forum](https://matsci.org/c/nomad/32).
+    For special cases of larger simulations or datasets that must be stored in full, special processing procedures are required. In this case, you should contact the [NOMAD/FAIRmat team]() for assistance. Alternatively, you can post questions or requests on the [NOMAD MATSCI Community Discourse Forum](https://matsci.org/c/nomad/32){:target="_blank"}.
 
 During the processing, NOMAD will store the simulation data and *metadata* within the NOMAD *Metainfo* schema. In this case, the parsing should take ~ 30 seconds. You should now see the successfully processed data overview:
 
@@ -70,7 +70,7 @@ The name of the upload can be modify by clicking on the pen icon :fontawesome-so
 - :fontawesome-solid-cloud-arrow-down: _Download files_: downloads all files present in the upload.
 - :fontawesome-solid-rotate-left: _Reload_: reloads the uploads page.
 - :fontawesome-solid-rotate: _Reprocess_: triggers again the processing of the uploaded data.
-- :fontawesome-solid-angle-left::fontawesome-solid-angle-right: _API_: generates a JSON response to use by the [NOMAD API](../glossary/glossary.md/#api).
+- :fontawesome-solid-angle-left::fontawesome-solid-angle-right: _API_: generates a query with a JSON body to use by the NOMAD API.
 - :fontawesome-solid-trash: _Delete the upload_: deletes completely the upload.
 
 <!-- ## The NOMAD API
@@ -102,7 +102,7 @@ The third section, _(3) Edit author metadata_, allows users to edit certain meta
     <img src="../assets/uploading_and_publishing/edit_author_metadata.png" alt="Edit author metadata." width="50%" title="Edit author metadata.">
 </p>
 
-The final section, _(4) Publish_, lets the user to publish the data with or without an embargo. This will be explained more in detail in [How-to publish data](howto_publish_data.md).
+The final section, (4) Publish_, lets the user to publish the data with or without an embargo. This will be explained more in detail in [How-to publish data](howto_publish_data.md).
 
 <div class="click-zoom">
     <label>
@@ -113,9 +113,9 @@ The final section, _(4) Publish_, lets the user to publish the data with or with
 
 ???+ warning
 
-    Please do not publish this test data! There is a [test deployment of NOMAD](https://nomad-lab.eu/prod/v1/test) where you can safely perform test publishing, as the data is periodically deleted.
+    Please, ***do not publish this test data***! There is a [test deployment of NOMAD](https://nomad-lab.eu/prod/v1/test){:target="_blank"} where you can safely perform test publishing, as the data is periodically deleted.
 
-Now go back to the second section, _(2) Process data_, which shows the processed data and the generated [entries](../glossary/glossary.md/#entries) in NOMAD:
+Now go back to the second section, _(2) Process data_, which shows the processed data and the generated entries in NOMAD:
 
 <div class="click-zoom">
     <label>
@@ -136,7 +136,7 @@ Finally, click on the **DATA** tab. Here you can navigate through the NOMAD *Met
 
 NOMAD stores all processed data in a well defined, structured, and machine readable format, known as the `archive`.
 The schema that defines the organization of (meta)data within the archive is known as the `MetaInfo`.
-More information can be found in the NOMAD docs: [An Introduction to Schemas and Structured Data in NOMAD](https://nomad-lab.eu/prod/v1/docs/schema/introduction.html).
+More information can be found in the NOMAD docs: [An Introduction to Schemas and Structured Data in NOMAD](https://nomad-lab.eu/prod/v1/docs/schema/introduction.html){:target="_blank"}.
 
 Duplicate your tab and go to `Analyze > The NOMAD Metainfo` in the top-left menu of NOMAD. Here you can navigate through or search the entire set of NOMAD Metainfo definitions.
 

--- a/docs/Tutorial-3_Extracting_Data_and_Trajectory_Analysis.md
+++ b/docs/Tutorial-3_Extracting_Data_and_Trajectory_Analysis.md
@@ -7,7 +7,7 @@ For this demonstration, we will utilize some tools from the nomad-lab software, 
 We suggest creating a virtual environment for this purpose. For example, using `conda`, you can set up the appropriate environment by first downloading the environment.yml file:
 
 <center>
-[Download environment.yml](../assets/md_tutorial_3/environment.yml){ .md-button }
+[Download environment.yml](assets/md_tutorial_3/environment.yml){ .md-button }
 </center>
 
 Then create a new conda environment with the following command:
@@ -30,7 +30,7 @@ conda env create -f environment.yml
 Or if you are using `virtualenv`:
 
 <center>
-[Download requirements.txt](../assets/md_tutorial_3/requirements.txt){ .md-button }
+[Download requirements.txt](assets/md_tutorial_3/requirements.txt){ .md-button }
 </center>
 
 ```python
@@ -86,7 +86,7 @@ In general, you can use the [NOMAD Application Programming Interface (API)](http
 - delete data
 - query all kinds of (meta)data: processed (from the archive), raw (from the repository), large bundles, individual entries, etc
 
-Each functionality has its own url, i.e. _endpoints_. There are over 60 different endpoints, each specialized in their own little subtask. You can find the full overview over at the [API dashboard](https://nomad-lab.eu/prod/v1/staging/api/v1/extensions/docs#/). It is highly recommended to have this page open when writing queries. Lastly, you can also use the dashboard to try out queries on the fly.
+Each functionality has its own url, i.e. _endpoints_. There are over 60 different endpoints, each specialized in their own little subtask. You can find the full overview over at the [API dashboard](https://nomad-lab.eu/prod/v1/staging/api/v1/extensions/docs#/){:target="_blank"}. It is highly recommended to have this page open when writing queries. Lastly, you can also use the dashboard to try out queries on the fly.
 
 In this first exercise, we will download the **processed molecular dynamics trajectory** of an **individual entry** to perform our own visualization and analysis.
 For this, we will be using the `/entries/{entry_id}`/archive. The `{entry_id}` here is variable, which you can get from the NOMAD website (or other API queries). Note that there are 3 versions of this endpoint: one that only gives you the metadata, one that returns the entire archive (`/download`), and a last wildcard that we will get into later (`/query`). These latter 2 options will be demonstrated below.
@@ -353,7 +353,7 @@ for frame_ind, frame in enumerate(section_system):
     </label>
 </div>
 
-As you may have noticed, one of our bottlenecks in visualizing the trajectory is downloading the data. This is due to the archive's size (35.8 MB, not too uncommon with MD entries). It may be the case that before committing to downloading the entire archive for further analysis we want to examine a particular quantity, e.g., the temperature trajectory. This is a job for the `/query` endpoint. Go back to the [API dashboard](https://nomad-lab.eu/prod/v1/staging/api/v1/extensions/docs#/entries%2Farchive/post_entry_archive_query_entries__entry_id__archive_query_post) and check out its schema.
+As you may have noticed, one of our bottlenecks in visualizing the trajectory is downloading the data. This is due to the archive's size (35.8 MB, not too uncommon with MD entries). It may be the case that before committing to downloading the entire archive for further analysis we want to examine a particular quantity, e.g., the temperature trajectory. This is a job for the `/query` endpoint. Go back to the [API dashboard](https://nomad-lab.eu/prod/v1/staging/api/v1/extensions/docs#/entries%2Farchive/post_entry_archive_query_entries__entry_id__archive_query_post){:target="_blank"} and check out its schema.
 
 This endpoint uses `post`, which is either used to add data (such as under `uploads`) or more complex queries and additional parameters, i.e. a more customizable `get` statement. This is in line with the standard semantics in HTTPS messages. In the case of our `/query` endpoint, the parameter we are looking for is `required` -the sections / quantities to be downloaded. Their specification follows the archive's tree structure as a nested dictionary. `requests` can append this information to the HTTPS body using the `json` argument. Below you will find the query specification. Pay attention to the optional use of indexes.
 

--- a/docs/part1.md
+++ b/docs/part1.md
@@ -15,20 +15,20 @@ When the information contains strategies for steering clear from mistakes, it wi
 Each scenario assumes that you completed the previous ones, or that you are at least familiar with its objectives and terminology introduced.
 
 We start the tutorial with a brief overview of the _NOMAD Archive and Repository_ (in short, _NOMAD-lab_).
- A more general tutorial can be found in the [FAIRmat tutorial 1](https://www.fairmat-nfdi.eu/events/fairmat-tutorial-1/tutorial-1-home).
+ A more general tutorial can be found in the [FAIRmat tutorial 1](https://www.fairmat-nfdi.eu/events/fairmat-tutorial-1/tutorial-1-home){:target="_blank"}.
 
 ## Navigating to the NOMAD {#entries_section}
 
 With the structure clear, let us jump into the NOMAD website.
 Only... there are several access points.
-The general [_landing page_](https://nomad-lab.eu/nomad-lab/) will give you a quick rundown of the NOMAD-lab, as wells as it features.
+The general [_landing page_](https://nomad-lab.eu/nomad-lab/){:target="_blank"} will give you a quick rundown of the NOMAD-lab, as wells as it features.
 Furthermore, it provides several links to documentation, tutorials, and the history behind the project.
 
 When accessing the data, however, we want to locate the NOMAD-lab itself.
 There are 2 public versions available:
 
-1. [stable](https://nomad-lab.eu/prod/v1/gui/search/entries), as the default, under "Open NOMAD" (highlighted <span style="color:orange">orange</span>).
-2. [beta /staging](https://nomad-lab.eu/prod/v1/staging/gui/search/entries), which has the latest release and updates much more frequently. As such, it could also harbor unstable or untested features.
+1. [stable](https://nomad-lab.eu/prod/v1/gui/search/entries){:target="_blank"}, as the default, under "Open NOMAD" (highlighted <span style="color:orange">orange</span>).
+2. [beta /staging](https://nomad-lab.eu/prod/v1/staging/gui/search/entries){:target="_blank"}, which has the latest release and updates much more frequently. As such, it could also harbor unstable or untested features.
 
 Unless anything breaks, we recommend using the beta version.
 It has links at the bottom-right corner of the landing page, as well as under "SOLUTIONS" > "NOMAD" > "Try and Test" (highlighted <span style="color:red">red</span>).
@@ -49,7 +49,7 @@ It has links at the bottom-right corner of the landing page, as well as under "S
 </div>
 
 To ensure the long-term reproducibility of this tutorial, we provide you with a link to the beta version, but capped at September 14th, 2023.
-Please visit this [NOMAD page](https://nomad-lab.eu/prod/v1/staging/gui/search/entries?upload_create_time[gte]=1419895487748&upload_create_time[lte]=1694679900000) and take a look at its layout.
+Please visit this [NOMAD page](https://nomad-lab.eu/prod/v1/staging/gui/search/entries?upload_create_time[gte]=1419895487748&upload_create_time[lte]=1694679900000){:target="_blank"} and take a look at its layout.
 
 As denoted at the top left, the page we have in front of us is called _Entries_.
 When loading the page, you should also see an orange box in the left-bottom corner, warning you that you are using an experimental product. You can get rid of it by clicking the check mark (`✓`).
@@ -242,7 +242,7 @@ Are there any other filters that you would like to try out, or do you prefer che
     - use all 4 types of search bar queries.
     - recognize "OR" filter stacking.
 
-Start a fresh session by clearing the molecular dynamics related filters, or by restoring the [initial session](https://nomad-lab.eu/prod/v1/staging/gui/search/entries?upload_create_time[gte]=1419895487748&upload_create_time[lte]=1694679900000).
+Start a fresh session by clearing the molecular dynamics related filters, or by restoring the [initial session](https://nomad-lab.eu/prod/v1/staging/gui/search/entries?upload_create_time[gte]=1419895487748&upload_create_time[lte]=1694679900000){:target="_blank"}.
 
 In this scenario our objective is more vaguely defined, so we will **start by exploring** the database before focusing in.
 A good overview is fundamental for spotting interesting data.
@@ -304,7 +304,7 @@ The formatting here is far stricter.
 While you can switch back to the side menu at any time, we will , for educational purposes, rely solely on the search bar throughout this scenario.
 
 ???+ info "Optimade"
-    NOMAD also supports the [Optimade](https://www.optimade.org/documentation) API, which has its own query conventions (not covered in this tutorial).
+    NOMAD also supports the [Optimade](https://www.optimade.org/documentation){:target="_blank"} API, which has its own query conventions (not covered in this tutorial).
     To use the NOMAD-Optimade endpoint, scroll down to "Optimade" at the very bottom of the side menu.
 
 We have a lot of leeway in which filters we tackle first.
@@ -411,7 +411,7 @@ By now, you probably have a good instinct of where to find them in the side menu
 Perform an **equality query** for both **"HSE03" and "HSE06"** (prominent hybrids in solid state).
 
 ???+ info "Density functional nomenclature"
-    The functional naming in NOMAD follows the **convention established by [libxc](https://github.com/ElectronicStructureLibrary/libxc)**, a popular library for evaluating (semi)local functionals.
+    The functional naming in NOMAD follows the **convention established by [libxc](https://github.com/ElectronicStructureLibrary/libxc){:target="_blank"}**, a popular library for evaluating (semi)local functionals.
     In practice, this goes as `<hybrid flag>_<Jacob's Ladder>_<exchange-correlation part>_<name identifier>`, where **`<name identifier>` is the main ID** and the other tags simply provide metadata.
     `<hybrid flag>` is only present when the functional truly is a hybrid.
 
@@ -447,7 +447,7 @@ These can all be found under the filter subgroup "Precision".
 It is tough to estimate these parameters' actual impact.
 Therefore, they are best left till the end of the full query.
 Then you can evaluate the cost-benefit of reducing the dataset size for higher homogeneity or precision.
-For a full rundown on these newer features, feel free to check out [FAIRmat Tutorial 10](https://www.fairmat-nfdi.eu/events/fairmat-tutorial-10/tutorial-10-home).
+For a full rundown on these newer features, feel free to check out [FAIRmat Tutorial 10](https://www.fairmat-nfdi.eu/events/fairmat-tutorial-10/tutorial-10-home){:target="_blank"}.
 <!-- This feature is quite recent.
 For it to have a significant impact, the NOMAD database has to run over all of 13 million entries and reprocess them.
 In other words, new features will always lag behind in old data.
@@ -547,9 +547,9 @@ Formulate a **presence query** for the _density of states_, commonly abbreviated
     - set up a dashboard.
     - examine an entry summary.
 
-Go back again to the [initial session](https://nomad-lab.eu/prod/v1/staging/gui/search/entries?upload_create_time[gte]=1419895487748&upload_create_time[lte]=1694679900000).
+Go back again to the [initial session](https://nomad-lab.eu/prod/v1/staging/gui/search/entries?upload_create_time[gte]=1419895487748&upload_create_time[lte]=1694679900000){:target="_blank"}.
 
-The obvious starting point would be use a search engine specialized in publications, such as [**Google Scholar**](https://scholar.google.com/).
+The obvious starting point would be use a search engine specialized in publications, such as [**Google Scholar**](https://scholar.google.com/){:target="_blank"}.
 Just searching by the author's (last?) name, yields a suggestion for "Robert A. Rose", who seems to be working in biomedicine.
 Not quite what we were looking for...
 You can **try adding some more terms** describing the field, e.g. _ab initio_, DFT or MOFs.
@@ -617,7 +617,7 @@ Overall, a **dashboard** should just provide a **quick summary**, for more speci
     Expanding their size is done by dragging the bottom-right corner (`∟`).
     Widgets start out at their minimal default.
 
-    For a great example of a rich dashboard, visit the [app under "Explore" > "Solar Cells"](https://nomad-lab.eu/prod/v1/staging/gui/search/solarcells).
+    For a great example of a rich dashboard, visit the [app under "Explore" > "Solar Cells"](https://nomad-lab.eu/prod/v1/staging/gui/search/solarcells){:target="_blank"}.
 
 ??? success
     Your dashboard should now look somewhat as in the reference figure.
@@ -695,7 +695,7 @@ Right-button click the **DOI hyperlink** and open the article in a new tab.
     When **in doubt, just hover** over the filter or quantity name.
 
 ??? success
-    You should now have [Machine learning the quantum-chemical properties of metal–organic frameworks for accelerated materials discovery](https://www.cell.com/matter/fulltext/S2590-2385(21)00070-9?_returnURL=https%3A%2F%2Flinkinghub.elsevier.com%2Fretrieve%2Fpii%2FS2590238521000709%3Fshowall%3Dtrue) in front of you.
+    You should now have [Machine learning the quantum-chemical properties of metal–organic frameworks for accelerated materials discovery](https://www.cell.com/matter/fulltext/S2590-2385(21)00070-9?_returnURL=https%3A%2F%2Flinkinghub.elsevier.com%2Fretrieve%2Fpii%2FS2590238521000709%3Fshowall%3Dtrue){:target="_blank"} in front of you.
     Indeed, next time you bump into your colleague, they will be surprised to learn that you already found it.
     Actually, any out of the 4 datasets would have brought you to the same paper as well.
     They are indeed part of the same publication.
@@ -719,10 +719,10 @@ Apparently there is _cited work (no. 147)_ that shows the effectiveness of HLE17
 
 !!! warning "Ignoring hidden complexity"
     While the naming of the datasets matches the density functional labels assigned by NOMAD, there could be other relevant information regarding the modelling.
-    A good practice would be check under ["Entry" > "DATA" > "run"](https://nomad-lab.eu/prod/v1/staging/gui/search/entries/entry/id/zxxFhlU1kL7SMJuygceeubfXJMGb/data/run/0) to find data that has no associated filter, or
-    take a look at the raw input under ["Entry" > "FILES"](https://nomad-lab.eu/prod/v1/staging/gui/search/entries/entry/id/zxxFhlU1kL7SMJuygceeubfXJMGb/files/_mainfile) in case the metadata was not extracted.
+    A good practice would be check under ["Entry" > "DATA" > "run"](https://nomad-lab.eu/prod/v1/staging/gui/search/entries/entry/id/zxxFhlU1kL7SMJuygceeubfXJMGb/data/run/0){:target="_blank"} to find data that has no associated filter, or
+    take a look at the raw input under ["Entry" > "FILES"](https://nomad-lab.eu/prod/v1/staging/gui/search/entries/entry/id/zxxFhlU1kL7SMJuygceeubfXJMGb/files/_mainfile){:target="_blank"} in case the metadata was not extracted.
 
-    In this case, the [INCAR](https://nomad-lab.eu/prod/v1/staging/gui/search/entries/entry/id/zxxFhlU1kL7SMJuygceeubfXJMGb/files/INCAR/preview) contains **Van der Waals terms** (D3 according to the text) as well.
+    In this case, the [INCAR](https://nomad-lab.eu/prod/v1/staging/gui/search/entries/entry/id/zxxFhlU1kL7SMJuygceeubfXJMGb/files/INCAR/preview){:target="_blank"} contains **Van der Waals terms** (D3 according to the text) as well.
     This is perfectly normal practice when modeling hydrocarbon chains, but was **not picked up on by NOMAD**.
     Support will be added in the future.
 
@@ -736,7 +736,7 @@ Indeed, Andrew Rosen made a big contribution to our coverage of MOFs.
 Such **contributions from the community** are what drive NOMAD.
 You may consider contributing your data already during the research/analysis process, right before submitting a publication, or even later on (especially for data that you have from older publications!).
 
-Andrew first even published his data over at [figshare](https://figshare.com/articles/dataset/QMOF_Database/13147324) and shortly after uploaded it to NOMAD.
+Andrew first even published his data over at [figshare](https://figshare.com/articles/dataset/QMOF_Database/13147324){:target="_blank"} and shortly after uploaded it to NOMAD.
 It is good that he did, since NOMAD provides much more information (the full calculation) and covers a wide search range.
 Meanwhile, over at _figshare_, you have to download a zip folder, not knowing what to exactly expect.
 Andrew clearly put some effort in providing a structured overview, focusing heavily on the MOF description and little else.


### PR DESCRIPTION
@JFRudzinski while the warnings coming from server are valid, it seems somehow capable of still finding back most of the broken links. The only exception is the glossary, which removed. The other links were updated.

Moreover, I made it so most hyperlinks now open in a new tab. Like this, the users keep having the tutorial in front of their eyes.

Feel free to merge as you see fit. It should not cause any issues with PR #13 .

closes #14 